### PR TITLE
feat(regex): Enhance regex matching for greater flexibility across various supported naming schemes

### DIFF
--- a/overlays/media_info.yml
+++ b/overlays/media_info.yml
@@ -116,87 +116,87 @@ templates:
       regex:
         conditions:
           - key: DV
-            value: '(?i)\[(?![^\]]*HDR10Plus)(?![^\]]*HDR10)[^\]]*DV\]'
+            value: '(?i)(?!HDR10Plus)(?!HDR10)]*DV'
           - key: HDR
-            value: '(?i)\[HDR10\]'
+            value: '(?i)HDR10'
           - key: Plus
-            value: '(?i)\[HDR10Plus\]'
+            value: '(?i)HDR10Plus'
           - key: DigitalPlus
-            value: '(?i)\[EAC3(?: 5\.1| 7\.1)?\]'
+            value: '(?i)EAC3(?:[ .]5\.1[ .]7\.1)?'
           - key: DTS-HD
-            value: '(?i)\[DTS-HD MA(?: 5\.1| 7\.1)?\]'
+            value: '(?i)DTS-HD[ .]MA(?:[ .]5\.1[ .]7\.1)?'
           - key: DTS-X
-            value: '(?i)\[DTS-X(?: 5\.1| 7\.1)?\]'
+            value: '(?i)DTS-X(?:[ .]5\.1[ .]7\.1)?'
           - key: TrueHD
-            value: '(?i)\[(?![^\]]*Atmos)[^\]]*TrueHD(?: 5\.1| 7\.1)?\]'
+            value: '(?i)(?!Atmos)TrueHD(?:[ .]5\.1[ .]7\.1)?'
           - key: Atmos
-            value: '(?i)\[EAC3 Atmos(?: 5\.1| 7\.1)?\]'
+            value: '(?i)EAC3[ .]Atmos(?:[ .]5\.1[ .]7\.1)?'
           - key: TrueHD-Atmos
-            value: '(?i)\[TrueHD Atmos(?: 5\.1| 7\.1)?\]'
+            value: '(?i)TrueHD[ .]Atmos(?:[ .]5\.1[ .]7\.1)?'
           - key: DV-HDR
-            value: '(?i)\[DV HDR10\]'
+            value: '(?i)DV[ .]HDR10'
           - key: DV-Plus
-            value: '(?i)\[DV HDR10Plus\]'
+            value: '(?i)DV[ .]HDR10Plus'
           - key: DV-DigitalPlus
-            value: '(?i)(?=.*\[(?![^\]]*HDR10Plus)(?![^\]]*HDR10)[^\]]*DV\])(?=.*\[EAC3(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*(?!HDR10Plus)(?!HDR10)DV)(?=.*EAC3(?:[ .]5\.1[ .]7\.1)?)'
           - key: HDR-DigitalPlus
-            value: '(?i)(?=.*\[HDR10\])(?=.*\[EAC3(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*HDR10)(?=.*EAC3(?:[ .]5\.1[ .]7\.1)?)'
           - key: Plus-DigitalPlus
-            value: '(?i)(?=.*\[HDR10Plus\])(?=.*\[EAC3(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*HDR10Plus)(?=.*EAC3(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-HDR-DigitalPlus
-            value: '(?i)(?=.*\[DV HDR10\])(?=.*\[EAC3(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*DV[ .]HDR10)(?=.*EAC3(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-Plus-DigitalPlus
-            value: '(?i)(?=.*\[DV HDR10Plus\])(?=.*\[EAC3(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*DV[ .]HDR10Plus)(?=.*EAC3(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-DTS-HD
-            value: '(?i)(?=.*\[(?![^\]]*HDR10Plus)(?![^\]]*HDR10)[^\]]*DV\])(?=.*\[DTS-HD MA(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*(?!HDR10Plus)(?!HDR10)DV)(?=.*DTS-HD[ .]MA(?:[ .]5\.1[ .]7\.1)?)'
           - key: HDR-DTS-HD
-            value: '(?i)(?=.*\[HDR10\])(?=.*\[DTS-HD MA(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*HDR10)(?=.*DTS-HD[ .]MA(?:[ .]5\.1[ .]7\.1)?)'
           - key: Plus-DTS-HD
-            value: '(?i)(?=.*\[HDR10Plus\])(?=.*\[DTS-HD MA(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*HDR10Plus)(?=.*DTS-HD[ .]MA(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-HDR-DTS-HD
-            value: '(?i)(?=.*\[DV HDR10\])(?=.*\[DTS-HD MA(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*DV[ .]HDR10)(?=.*DTS-HD[ .]MA(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-Plus-DTS-HD
-            value: '(?i)(?=.*\[DV HDR10Plus\])(?=.*\[DTS-HD MA(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*DV[ .]HDR10Plus)(?=.*DTS-HD[ .]MA(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-DTS-X
-            value: '(?i)(?=.*\[(?![^\]]*HDR10Plus)(?![^\]]*HDR10)[^\]]*DV\])(?=.*\[DTS-X(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*(?!HDR10Plus)(?!HDR10)DV)(?=.*DTS-X(?:[ .]5\.1[ .]7\.1)?)'
           - key: HDR-DTS-X
-            value: '(?i)(?=.*\[HDR10\])(?=.*\[DTS-X(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*HDR10)(?=.*DTS-X(?:[ .]5\.1[ .]7\.1)?)'
           - key: Plus-DTS-X
-            value: '(?i)(?=.*\[HDR10Plus\])(?=.*\[DTS-X(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*HDR10Plus)(?=.*DTS-X(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-HDR-DTS-X
-            value: '(?i)(?=.*\[DV HDR10\])(?=.*\[DTS-X(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*DV[ .]HDR10)(?=.*DTS-X(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-Plus-DTS-X
-            value: '(?i)(?=.*\[DV HDR10Plus\])(?=.*\[DTS-X(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*DV[ .]HDR10Plus)(?=.*DTS-X(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-Atmos
-            value: '(?i)(?=.*\[(?![^\]]*HDR10Plus)(?![^\]]*HDR10)[^\]]*DV\])(?=.*\[EAC3 Atmos(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*(?!HDR10Plus)(?!HDR10)DV)(?=.*EAC3[ .]Atmos(?:[ .]5\.1[ .]7\.1)?)'
           - key: HDR-Atmos
-            value: '(?i)(?=.*\[HDR10\])(?=.*\[EAC3 Atmos(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*HDR10)(?=.*EAC3[ .]Atmos(?:[ .]5\.1[ .]7\.1)?)'
           - key: Plus-Atmos
-            value: '(?i)(?=.*\[HDR10Plus\])(?=.*\[EAC3 Atmos(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*HDR10Plus)(?=.*EAC3[ .]Atmos(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-HDR-Atmos
-            value: '(?i)(?=.*\[DV HDR10\])(?=.*\[EAC3 Atmos(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*DV[ .]HDR10)(?=.*EAC3[ .]Atmos(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-Plus-Atmos
-            value: '(?i)(?=.*\[DV HDR10Plus\])(?=.*\[EAC3 Atmos(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*DV[ .]HDR10Plus)(?=.*EAC3[ .]Atmos(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-TrueHD
-            value: '(?i)(?=.*\[(?![^\]]*HDR10Plus)(?![^\]]*HDR10)[^\]]*DV\])(?=.*\[(?![^\]]*Atmos)[^\]]*TrueHD(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*(?!HDR10Plus)(?!HDR10)DV)(?=.*(?!Atmos)TrueHD(?:[ .]5\.1[ .]7\.1)?)'
           - key: HDR-TrueHD
-            value: '(?i)(?=.*\[HDR10\])(?=.*\[(?![^\]]*Atmos)[^\]]*TrueHD(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*HDR10)(?=.*(?!Atmos)TrueHD(?:[ .]5\.1[ .]7\.1)?)'
           - key: Plus-TrueHD
-            value: '(?i)(?=.*\[HDR10Plus\])(?=.*\[(?![^\]]*Atmos)[^\]]*TrueHD(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*HDR10Plus)(?=.*(?!Atmos)TrueHD(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-HDR-TrueHD
-            value: '(?i)(?=.*\[DV HDR10\])(?=.*\[(?![^\]]*Atmos)[^\]]*TrueHD(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*DV[ .]HDR10)(?=.*(?!Atmos)TrueHD(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-Plus-TrueHD
-            value: '(?i)(?=.*\[DV HDR10Plus\])(?=.*\[(?![^\]]*Atmos)[^\]]*TrueHD(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*DV[ .]HDR10Plus)(?=.*(?!Atmos)TrueHD(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-TrueHD-Atmos
-            value: '(?i)(?=.*\[(?![^\]]*HDR10Plus)(?![^\]]*HDR10)[^\]]*DV\])(?=.*\[TrueHD Atmos(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*(?!HDR10Plus)(?!HDR10)DV)(?=.*TrueHD[ .]Atmos(?:[ .]5\.1[ .]7\.1)?)'
           - key: HDR-TrueHD-Atmos
-            value: '(?i)(?=.*\[HDR10\])(?=.*\[TrueHD Atmos(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*HDR10)(?=.*TrueHD[ .]Atmos(?:[ .]5\.1[ .]7\.1)?)'
           - key: Plus-TrueHD-Atmos
-            value: '(?i)(?=.*\[HDR10Plus\])(?=.*\[TrueHD Atmos(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*HDR10Plus)(?=.*TrueHD[ .]Atmos(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-HDR-TrueHD-Atmos
-            value: '(?i)(?=.*\[DV HDR10\])(?=.*\[TrueHD Atmos(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*DV[ .]HDR10)(?=.*TrueHD[ .]Atmos(?:[ .]5\.1[ .]7\.1)?)'
           - key: DV-Plus-TrueHD-Atmos
-            value: '(?i)(?=.*\[DV HDR10Plus\])(?=.*\[TrueHD Atmos(?: 5\.1| 7\.1)?\])'
+            value: '(?i)(?=.*DV[ .]HDR10Plus)(?=.*TrueHD[ .]Atmos(?:[ .]5\.1[ .]7\.1)?)'
     optional:
       - use_<<type>>
     run_definition:
@@ -235,41 +235,41 @@ templates:
       regex:
         conditions:
           - key: IMAX
-            value: '(?i)\{edition-IMAX[^}]*\}'
+            value: '(?i)\{(edition-)IMAX[^}]*\}'
           - key: Unrated-Edition
-            value: '(?i)\{edition-Unrated[^}]*\}'
+            value: '(?i)\{(edition-)Unrated[^}]*\}'
           - key: Directors-Cut
-            value: '(?i)\{edition-(Director|Ultimate Director)[^}]*\}'
+            value: '(?i)\{(edition-)(Director|Ultimate Director)[^}]*\}'
           - key: Special-Edition
-            value: '(?i)\{edition-Special[^}]*\}'
+            value: '(?i)\{(edition-)Special[^}]*\}'
           - key: Anniversary-Edition
-            value: '(?i)\{edition-\d+th Anniversary[^}]*\}'
+            value: '(?i)\{(edition-)\d+th Anniversary[^}]*\}'
           - key: Collectors-Edition
-            value: '(?i)\{edition-Collector[^}]*\}'
+            value: '(?i)\{(edition-)Collector[^}]*\}'
           - key: Minus-Color
-            value: '(?i)\{edition-Minus Color[^}]*\}'
+            value: '(?i)\{(edition-)Minus Color[^}]*\}'
           - key: Extended-Cut
-            value: '(?i)\{edition-Extended Cut[^}]*\}'
+            value: '(?i)\{(edition-)Extended Cut[^}]*\}'
           - key: Extended-Edition
-            value: '(?i)\{edition-Extended(?! Cut)[^}]*\}'
+            value: '(?i)\{(edition-)Extended(?! Cut)[^}]*\}'
           - key: Open-Matte
-            value: '(?i)\{edition-Open Matte[^}]*\}'
+            value: '(?i)\{(edition-)Open Matte[^}]*\}'
           - key: Final-Cut
-            value: '(?i)\{edition-Final Cut[^}]*\}'
+            value: '(?i)\{(edition-)Final Cut[^}]*\}'
           - key: Remastered
-            value: '(?i)\{edition-Remastered[^}]*\}'
+            value: '(?i)\{(edition-)Remastered[^}]*\}'
           - key: Restored
-            value: '(?i)\{edition-Restored[^}]*\}'
+            value: '(?i)\{(edition-)Restored[^}]*\}'
           - key: Signature-Edition
-            value: '(?i)\{edition-Signature[^}]*\}'
+            value: '(?i)\{(edition-)Signature[^}]*\}'
           - key: Theatrical
-            value: '(?i)\{edition-Theatrical(?! Cut)[^}]*\}'
+            value: '(?i)\{(edition-)Theatrical(?! Cut)[^}]*\}'
           - key: Theatrical-Cut
-            value: '(?i)\{edition-Theatrical Cut[^}]*\}'
+            value: '(?i)\{(edition-)Theatrical Cut[^}]*\}'
           - key: Uncut
-            value: '(?i)\{edition-Uncut[^}]*\}'
+            value: '(?i)\{(edition-)Uncut[^}]*\}'
           - key: Ultimate-Edition
-            value: '(?i)\{edition-Ultimate(?! Director)[^}]*\}'
+            value: '(?i)\{(edition-)Ultimate(?! Director)[^}]*\}'
     optional:
       - use_<<type>>
       - allowed_libraries


### PR DESCRIPTION
- Improved audio/HDR formats regex matching to support all Plex naming schemes, including the NEW P2P/Scene Naming https://github.com/TRaSH-Guides/Guides/pull/2416
- Improved edition regex matching to support `{edition-{Edition Tags}}` and `{Edition Tags}`